### PR TITLE
Performance fixes and fast hfun prototyping features

### DIFF
--- a/geomesh/__main__.py
+++ b/geomesh/__main__.py
@@ -73,6 +73,7 @@ class Geomesh:
                     hmin=self._args.hmin,
                     hmax=self._args.hmax,
                     contours=self._args.contour,
+                    constants=self._args.constants,
                     chunk_size=self._args.chunk_size,
                     overlap=self._args.overlap,
                     nprocs=nprocs)
@@ -362,6 +363,12 @@ def parse_args():
         '--contour', action='append', nargs='+', type=float,
         help="Each contour's (level, [expansion, target])"
              " to be applied on all size functions in collector")
+    hfun_bld.add_argument(
+        '--constant',
+        action='append', nargs=2, type=float, dest='constants',
+        metavar='CONST_DEFN', default=list(),
+        help="Specify constant mesh size above a given contour level"
+             " by passing (lower_bound, target_size) for each constant")
     hfun_bld.add_argument(
         'dem', nargs='+',
         help='Digital elevation model list to be used in size function creation')

--- a/geomesh/__main__.py
+++ b/geomesh/__main__.py
@@ -52,7 +52,9 @@ class Geomesh:
                     zmax=self._args.zmax,
                     chunk_size=self._args.chunk_size,
                     overlap=self._args.overlap,
-                    nprocs=nprocs)
+                    nprocs=nprocs,
+                    out_crs=self._args.output_crs,
+                    base_crs=self._args.mesh_crs)
                 combine_geometry(**arg_dict)
 
         elif self._args.command == 'hfun':
@@ -332,7 +334,10 @@ def parse_args():
     geom_bld = geom_subp.add_parser('build', **sub_parse_common)
     geom_bld.add_argument('-o', '--output', required=True)
     geom_bld.add_argument('-f', '--output-format', default="shapefile")
+    geom_bld.add_argument('--output-crs', default="EPSG:4326")
     geom_bld.add_argument('--mesh', help='Mesh to extract hull from')
+    geom_bld.add_argument(
+        '--mesh-crs', help='CRS of the input base mesh (overrides)')
     geom_bld.add_argument(
         '--zmin', type=float,
         help='Maximum elevation to consider')

--- a/geomesh/__main__.py
+++ b/geomesh/__main__.py
@@ -76,6 +76,7 @@ class Geomesh:
                     constants=self._args.constants,
                     chunk_size=self._args.chunk_size,
                     overlap=self._args.overlap,
+                    method=self._args.method,
                     nprocs=nprocs)
                 combine_hfun(**arg_dict)
 
@@ -369,6 +370,9 @@ def parse_args():
         metavar='CONST_DEFN', default=list(),
         help="Specify constant mesh size above a given contour level"
              " by passing (lower_bound, target_size) for each constant")
+    hfun_bld.add_argument(
+        '--method', type=str, default='exact',
+        help='Method used to calculate size function ({exact} |fast)')
     hfun_bld.add_argument(
         'dem', nargs='+',
         help='Digital elevation model list to be used in size function creation')

--- a/geomesh/cmd/remesh.py
+++ b/geomesh/cmd/remesh.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
 import os
+import gc
 import logging
 import argparse
 from pathlib import Path
@@ -181,6 +182,8 @@ def main(args):
                     {'geometry': gpd.GeoSeries(poly_geom)},
                     crs=geom.crs
                 ).to_file(str(out_path)+'.geom.shp')
+            del poly_geom
+            gc.collect()
 
             _logger.info("Calculating final size function")
             jig_hfun = hfun.msh_t()
@@ -190,6 +193,8 @@ def main(args):
             Mesh(jig_hfun).write(
                 str(out_path)+'.hfun.2dm',
                 format='2dm', overwrite=True)
+            del jig_hfun
+            gc.collect()
 
             # Read back from file to avoid recalculation of hfun
             # and geom

--- a/geomesh/driver.py
+++ b/geomesh/driver.py
@@ -89,10 +89,12 @@ class JigsawDriver:
         self.opts.hfun_hmin = np.min(hfun_msh_t.value)
         self.opts.hfun_hmax = np.max(hfun_msh_t.value)
 
+        geom_msh_t = self.geom.msh_t()
+
         _logger.info('Calling libsaw.jigsaw() ...')
         libsaw.jigsaw(
             self.opts,
-            self.geom.msh_t(),
+            geom_msh_t,
             output_mesh,
             init=hfun_msh_t if self._init is True else None,
             hfun=hfun_msh_t
@@ -108,6 +110,9 @@ class JigsawDriver:
             utils.reproject(output_mesh, self._crs)
 
         _logger.info('Finalizing mesh...')
+        if self.opts.hfun_hmin > 0:
+            output_mesh = utils.remesh_small_elements(
+                self.opts, geom_msh_t, output_mesh, hfun_msh_t)
         utils.finalize_mesh(output_mesh, sieve)
 
         _logger.info('done!')

--- a/geomesh/hfun/collector.py
+++ b/geomesh/hfun/collector.py
@@ -701,7 +701,7 @@ class HfunCollector(BaseHfun):
             if zmin is None:
                 zmin = -99990
             else:
-                zmin = min(zmin, -99990)
+                zmin = max(zmin, -99990)
 
             big_hfun.add_subtidal_flow_limiter(hmin, hmax, zmax, zmin)
 

--- a/geomesh/hfun/collector.py
+++ b/geomesh/hfun/collector.py
@@ -13,7 +13,7 @@ from typing import Union, Sequence, List
 
 import geopandas as gpd
 from pyproj import CRS, Transformer
-from shapely.geometry import MultiPolygon, Polygon, GeometryCollection
+from shapely.geometry import MultiPolygon, Polygon, GeometryCollection, box
 from shapely import ops
 from jigsawpy import jigsaw_msh_t
 from rasterio.transform import from_origin, Affine
@@ -620,8 +620,10 @@ class HfunCollector(BaseHfun):
             proj='utm', zone=f'{number}{letter}', ellps='WGS84')
         transformer = Transformer.from_crs(
                 'EPSG:4326', utm_crs, always_xy=True)
-        (x0, x1), (y0, y1) = transformer.transform(
-                [x0, x1], [y0, y1])
+
+        box_epsg4326 = box(x0, y0, x1, y1)
+        poly_utm = ops.transform(transformer.transform, Polygon(box_epsg4326))
+        x0, y0, x1, y1 = poly_utm.bounds
 
         # TODO: What if no hmin? -> use smallest raster res!
         g_hmin = self._size_info['hmin']

--- a/geomesh/hfun/collector.py
+++ b/geomesh/hfun/collector.py
@@ -322,8 +322,8 @@ class HfunCollector(BaseHfun):
         contourable_list = [
             i for i in self._hfun_list if isinstance(i, HfunRaster)]
 
-        with Pool(processes=self._nprocs) as p:
-            with tempfile.TemporaryDirectory() as temp_path:
+        with tempfile.TemporaryDirectory() as temp_path:
+            with Pool(processes=self._nprocs) as p:
                 self._contour_coll.calculate(contourable_list, temp_path)
                 counter = 0
                 for hfun in contourable_list:
@@ -339,7 +339,7 @@ class HfunCollector(BaseHfun):
                                 'target_size': row.target_size,
                                 'proc_pool': p
                             })
-        p.join()
+            p.join()
             # hfun objects cause issue with pickling
             # -> cannot be passed to pool
 #            with Pool(processes=self._nprocs) as p:
@@ -392,10 +392,16 @@ class HfunCollector(BaseHfun):
         file_counter = 0
         pid = os.getpid()
         bbox_list = list()
-        # TODO: Should basemesh be included?
+
+        # TODO: Ask for user input to consider size from mesh?
+        hfun_list = self._hfun_list[::-1]
+        if self._base_mesh:
+            self._base_mesh.size_from_mesh()
+            hfun_list = [*self._hfun_list[::-1], self._base_mesh]
+
         # Last user input item has the highest priority (its trias
         # are not dropped) so process in reverse order
-        for hfun in self._hfun_list[::-1]:
+        for hfun in hfun_list:
             # TODO: Calling msh_t() on HfunMesh more than once causes
             # issue right now due to change in crs of internal Mesh
 

--- a/geomesh/hfun/collector.py
+++ b/geomesh/hfun/collector.py
@@ -384,7 +384,9 @@ class HfunCollector(BaseHfun):
         contourable_list = [
             i for i in self._hfun_list if isinstance(i, HfunRaster)]
         if apply_to is None:
-            apply_to = contourable_list
+            mesh_hfun_list = [
+                i for i in self._hfun_list if isinstance(i, HfunMesh)]
+            apply_to = [*mesh_hfun_list, *contourable_list]
 
         with tempfile.TemporaryDirectory() as temp_path:
             with Pool(processes=self._nprocs) as p:
@@ -683,7 +685,10 @@ class HfunCollector(BaseHfun):
         # NOTE: Caching applied doesn't work here since we apply
         # everything on a temporary big raster
         hfun = HfunRaster(big_raster, **self._size_info)
-        self._apply_contours([hfun])
+
+        mesh_hfun_list = [
+            i for i in self._hfun_list if isinstance(i, HfunMesh)]
+        self._apply_contours([*mesh_hfun_list, hfun])
         self._apply_flow_limiters_fast(hfun)
         self._apply_const_val_fast(hfun)
         self._apply_patch([hfun])

--- a/geomesh/hfun/collector.py
+++ b/geomesh/hfun/collector.py
@@ -676,7 +676,6 @@ class HfunCollector(BaseHfun):
                 for win in write_wins:
                     z = np.full((win.width, win.height), -99999, dtype=np.float32)
                     dst.write(z, 1, window=win)
-                del z, zview
 
             else:
                 z = np.full((shape0, shape1), -99999, dtype=np.float32)

--- a/geomesh/hfun/mesh.py
+++ b/geomesh/hfun/mesh.py
@@ -166,3 +166,6 @@ class HfunMesh(BaseHfun):
     @property
     def crs(self):
         return self._crs
+
+    def get_bbox(self, **kwargs):
+        return self.mesh.get_bbox(**kwargs)

--- a/geomesh/hfun/mesh.py
+++ b/geomesh/hfun/mesh.py
@@ -1,11 +1,21 @@
+import functools
 import logging
+import operator
 from copy import deepcopy
 from collections import defaultdict
+from typing import Union, List
+from multiprocessing import cpu_count, Pool
+from time import time
 
+from scipy.spatial import cKDTree
 from jigsawpy import jigsaw_msh_t
 import numpy as np
 from pyproj import CRS, Transformer
 import utm
+from shapely import ops
+from shapely.geometry import (
+    LineString, MultiLineString, box, GeometryCollection,
+    Polygon, MultiPolygon)
 
 from geomesh.hfun.base import BaseHfun
 from geomesh.crs import CRS as CRSDescriptor
@@ -162,6 +172,166 @@ class HfunMesh(BaseHfun):
         # NOTE: Modifying values of underlying mesh
         hfun_msh.value = vert_value.reshape(len(vert_value), 1)
 
+    def add_feature(
+            self,
+            feature: Union[LineString, MultiLineString],
+            expansion_rate: float,
+            target_size: float = None,
+            nprocs=None,
+            max_verts=200,
+            proc_pool=None
+    ):
+        if proc_pool is not None:
+            self._add_feature_internal(
+                feature=feature,
+                expansion_rate=expansion_rate,
+                target_size=target_size,
+                pool=proc_pool,
+                max_verts=max_verts)
+
+        else:
+            # Check nprocs
+            nprocs = -1 if nprocs is None else nprocs
+            nprocs = cpu_count() if nprocs == -1 else nprocs
+            _logger.debug(f'Using nprocs={nprocs}')
+
+            with Pool(processes=nprocs) as pool:
+                self._add_feature_internal(
+                    feature=feature,
+                    expansion_rate=expansion_rate,
+                    target_size=target_size,
+                    pool=pool,
+                    max_verts=max_verts)
+            pool.join()
+
+    def _add_feature_internal(
+            self,
+            feature: Union[LineString, MultiLineString],
+            expansion_rate: float,
+            target_size: float = None,
+            pool: Pool = None,
+            max_verts=200
+    ):
+        # TODO: Partition features if they are too "long" which results in an
+        # improvement for parallel pool. E.g. if a feature is too long, 1
+        # processor will be busy and the rest will be idle.
+
+        if not isinstance(feature, (LineString, MultiLineString)):
+            raise TypeError(
+                f'Argument feature must be of type {LineString} or '
+                f'{MultiLineString}, not type {type(feature)}.')
+
+        if isinstance(feature, LineString):
+            feature = [feature]
+
+        elif isinstance(feature, MultiLineString):
+            feature = [linestring for linestring in feature]
+
+        # check target size
+        target_size = self.hmin if target_size is None else target_size
+        if target_size is None:
+            raise ValueError('Argument target_size must be specified if no '
+                             'global hmin has been set.')
+        if target_size <= 0:
+            raise ValueError("Argument target_size must be greater than zero.")
+
+        utm_crs: Union[CRS, None] = None
+        
+        if self.crs.is_geographic:
+            x0, y0, x1, y1 = self.mesh.get_bbox().bounds
+            _, _, number, letter = utm.from_latlon(
+                (y0 + y1)/2, (x0 + x1)/2)
+            utm_crs = CRS(
+                proj='utm',
+                zone=f'{number}{letter}',
+                ellps={
+                    'GRS 1980': 'GRS80',
+                    'WGS 84': 'WGS84'
+                    }[self.crs.ellipsoid.name]
+            )
+        else:
+            utm_crs = None
+
+        _logger.info('Repartitioning features...')
+        start = time()
+        res = pool.starmap(
+            repartition_features,
+            [(linestring, max_verts) for linestring in feature]
+            )
+        feature = functools.reduce(operator.iconcat, res, [])
+        _logger.info(f'Repartitioning features took {time()-start}.')
+
+        _logger.info(f'Resampling features on ...')
+        start = time()
+
+        # We don't want to recreate the same transformation
+        # many times (it takes time) and we can't pass
+        # transformation object to subtask (cinit issue)
+        transformer = None
+        if utm_crs is not None:
+            start2 = time()
+            transformer = Transformer.from_crs(
+                self.crs, utm_crs, always_xy=True)
+            _logger.info(
+                    f"Transform creation took {time() - start2:f}")
+            start2 = time()
+            feature = [
+                ops.transform(transformer.transform, linestring)
+                for linestring in feature]
+            _logger.info(
+                    f"Transform apply took {time() - start2:f}")
+
+        transformed_features = pool.starmap(
+            transform_linestring,
+            [(linestring, target_size) for linestring in feature]
+        )
+        _logger.info(f'Resampling features took {time()-start}.')
+        _logger.info('Concatenating points...')
+        start = time()
+        points = []
+        for geom in transformed_features:
+            if isinstance(geom, LineString):
+                points.extend(geom.coords)
+            elif isinstance(geom, MultiLineString):
+                for linestring in geom:
+                    points.extend(linestring.coords)
+        _logger.info(f'Point concatenation took {time()-start}.')
+
+        _logger.info('Generating KDTree...')
+        start = time()
+        tree = cKDTree(np.array(points))
+        _logger.info(f'Generating KDTree took {time()-start}.')
+
+        # We call msh_t() so that it also takes care of utm 
+        # transformation
+        xy = self.msh_t().vert2['coord']
+
+        _logger.info(f'transforming points took {time()-start}.')
+        _logger.info('querying kdtree...')
+        start = time()
+        if self.hmax:
+            r = (self.hmax - target_size) / (expansion_rate * target_size)
+            near_dists, neighbors = tree.query(
+                xy, workers=pool._processes, distance_upper_bound=r)
+            distances = r * np.ones(len(xy))
+            mask = np.logical_not(np.isinf(near_dists))
+            distances[mask] = near_dists[mask]
+        else:
+            distances, _ = tree.query(xy, workers=pool._processes)
+        _logger.info(f'querying kdtree took {time()-start}.')
+        values = expansion_rate*target_size*distances + target_size
+        # NOTE: unlike raster self.hmin is based on values of this
+        # hfun before applying feature; it is ignored so that
+        # the new self.hmin becomes equal to "target" specified
+#        if self.hmin is not None:
+#            values[np.where(values < self.hmin)] = self.hmin
+        if self.hmax is not None:
+            values[np.where(values > self.hmax)] = self.hmax
+        values = np.minimum(self.mesh.msh_t.value.ravel(), values)
+        values = values.reshape(self.mesh.msh_t.value.shape)
+
+        self.mesh.msh_t.value = values
+
     @property
     def hmin(self):
         return np.min(self.mesh.msh_t.value)
@@ -180,3 +350,36 @@ class HfunMesh(BaseHfun):
 
     def get_bbox(self, **kwargs):
         return self.mesh.get_bbox(**kwargs)
+
+
+def transform_linestring(
+    linestring: LineString,
+    target_size: float,
+):
+    distances = [0.]
+    while distances[-1] + target_size < linestring.length:
+        distances.append(distances[-1] + target_size)
+    distances.append(linestring.length)
+    linestring = LineString([
+        linestring.interpolate(distance)
+        for distance in distances
+        ])
+    return linestring
+
+
+def repartition_features(linestring, max_verts):
+    features = []
+    if len(linestring.coords) > max_verts:
+        new_feat = []
+        for segment in list(map(LineString, zip(
+                linestring.coords[:-1],
+                linestring.coords[1:]))):
+            new_feat.append(segment)
+            if len(new_feat) == max_verts - 1:
+                features.append(ops.linemerge(new_feat))
+                new_feat = []
+        if len(new_feat) != 0:
+            features.append(ops.linemerge(new_feat))
+    else:
+        features.append(linestring)
+    return features

--- a/geomesh/hfun/raster.py
+++ b/geomesh/hfun/raster.py
@@ -211,7 +211,7 @@ class HfunRaster(BaseHfun, Raster):
                     np.flipud(self.get_values(window=window, band=1)),
                     dtype=jigsaw_msh_t.REALS_t)
                 kwargs = {'kx': 1, 'ky': 1}  # type: ignore[dict-item]
-                geom = PolygonGeom(box(x0, y0, x1, y1), self.crs).msh_t()
+                geom = PolygonGeom(box(x0, y1, x1, y0), self.crs).msh_t()
 
             _logger.info(f'Initial hfun generation took {time()-start}.')
 
@@ -233,7 +233,6 @@ class HfunRaster(BaseHfun, Raster):
                 verbosity
 
             # mesh of hfun window
-
             window_mesh = jigsaw_msh_t()
             window_mesh.mshID = 'euclidean-mesh'
             window_mesh.ndims = +2

--- a/geomesh/hfun/raster.py
+++ b/geomesh/hfun/raster.py
@@ -539,7 +539,7 @@ class HfunRaster(BaseHfun, Raster):
                     repartition_features,
                     [(linestring, max_verts) for linestring in feature]
                     )
-                feature = functools.reduce(operator.iconcat, res, [])
+                win_feature = functools.reduce(operator.iconcat, res, [])
                 _logger.info(f'Repartitioning features took {time()-start}.')
 
                 _logger.info(f'Resampling features on ...')
@@ -556,15 +556,15 @@ class HfunRaster(BaseHfun, Raster):
                     _logger.info(
                             f"Transform creation took {time() - start2:f}")
                     start2 = time()
-                    feature = [
+                    win_feature = [
                         ops.transform(transformer.transform, linestring)
-                        for linestring in feature]
+                        for linestring in win_feature]
                     _logger.info(
                             f"Transform apply took {time() - start2:f}")
 
                 transformed_features = pool.starmap(
                     transform_linestring,
-                    [(linestring, target_size) for linestring in feature]
+                    [(linestring, target_size) for linestring in win_feature]
                 )
                 _logger.info(f'Resampling features took {time()-start}.')
                 _logger.info('Concatenating points...')

--- a/geomesh/hfun/raster.py
+++ b/geomesh/hfun/raster.py
@@ -313,6 +313,8 @@ class HfunRaster(BaseHfun, Raster):
             nprocs: int = None
     ):
 
+        # TODO: Add pool input support like add_feature for performance
+
         # TODO: Support other shapes - call buffer(1) on non polygons(?)
         if not isinstance(multipolygon, (Polygon, MultiPolygon)):
             raise TypeError(
@@ -439,6 +441,38 @@ class HfunRaster(BaseHfun, Raster):
             expansion_rate: float,
             target_size: float = None,
             nprocs=None,
+            max_verts=200,
+            proc_pool=None
+    ):
+        if proc_pool is not None:
+            self._add_feature_internal(
+                feature=feature,
+                expansion_rate=expansion_rate,
+                target_size=target_size,
+                pool=proc_pool,
+                max_verts=max_verts)
+
+        else:
+            # Check nprocs
+            nprocs = -1 if nprocs is None else nprocs
+            nprocs = cpu_count() if nprocs == -1 else nprocs
+            _logger.debug(f'Using nprocs={nprocs}')
+
+            with Pool(processes=nprocs) as pool:
+                self._add_feature_internal(
+                    feature=feature,
+                    expansion_rate=expansion_rate,
+                    target_size=target_size,
+                    pool=pool,
+                    max_verts=max_verts)
+            pool.join()
+
+    def _add_feature_internal(
+            self,
+            feature: Union[LineString, MultiLineString],
+            expansion_rate: float,
+            target_size: float = None,
+            pool: Pool = None,
             max_verts=200
     ):
         '''Adds a linear distance size function constraint to the mesh.
@@ -459,10 +493,6 @@ class HfunRaster(BaseHfun, Raster):
         # improvement for parallel pool. E.g. if a feature is too long, 1
         # processor will be busy and the rest will be idle.
 
-        # Check nprocs
-        nprocs = -1 if nprocs is None else nprocs
-        nprocs = cpu_count() if nprocs == -1 else nprocs
-        _logger.debug(f'Using nprocs={nprocs}')
         if not isinstance(feature, (LineString, MultiLineString)):
             raise TypeError(
                 f'Argument feature must be of type {LineString} or '
@@ -506,41 +536,37 @@ class HfunRaster(BaseHfun, Raster):
                     utm_crs = None
                 _logger.info('Repartitioning features...')
                 start = time()
-                with Pool(processes=nprocs) as pool:
-                    res = pool.starmap(
-                        repartition_features,
-                        [(linestring, max_verts) for linestring in feature]
-                        )
-                pool.join()
+                res = pool.starmap(
+                    repartition_features,
+                    [(linestring, max_verts) for linestring in feature]
+                    )
                 feature = functools.reduce(operator.iconcat, res, [])
                 _logger.info(f'Repartitioning features took {time()-start}.')
 
-                _logger.info(f'Resampling features on nprocs {nprocs}...')
+                _logger.info(f'Resampling features on ...')
                 start = time()
-                with Pool(processes=nprocs) as pool:
 
-                    # We don't want to recreate the same transformation
-                    # many times (it takes time) and we can't pass
-                    # transformation object to subtask (cinit issue)
-                    transformer = None
-                    if utm_crs is not None:
-                        start2 = time()
-                        transformer = Transformer.from_crs(
-                            self.src.crs, utm_crs, always_xy=True)
-                        _logger.info(
-                                f"Transform creation took {time() - start2:f}")
-                        start2 = time()
-                        feature = [
-                            ops.transform(transformer.transform, linestring)
-                            for linestring in feature]
-                        _logger.info(
-                                f"Transform apply took {time() - start2:f}")
+                # We don't want to recreate the same transformation
+                # many times (it takes time) and we can't pass
+                # transformation object to subtask (cinit issue)
+                transformer = None
+                if utm_crs is not None:
+                    start2 = time()
+                    transformer = Transformer.from_crs(
+                        self.src.crs, utm_crs, always_xy=True)
+                    _logger.info(
+                            f"Transform creation took {time() - start2:f}")
+                    start2 = time()
+                    feature = [
+                        ops.transform(transformer.transform, linestring)
+                        for linestring in feature]
+                    _logger.info(
+                            f"Transform apply took {time() - start2:f}")
 
-                    transformed_features = pool.starmap(
-                        transform_linestring,
-                        [(linestring, target_size) for linestring in feature]
-                    )
-                pool.join()
+                transformed_features = pool.starmap(
+                    transform_linestring,
+                    [(linestring, target_size) for linestring in feature]
+                )
                 _logger.info(f'Resampling features took {time()-start}.')
                 _logger.info('Concatenating points...')
                 start = time()
@@ -568,12 +594,12 @@ class HfunRaster(BaseHfun, Raster):
                 if self.hmax:
                     r = (self.hmax - target_size) / (expansion_rate * target_size)
                     near_dists, neighbors = tree.query(
-                        xy, workers=nprocs, distance_upper_bound=r)
+                        xy, workers=pool._processes, distance_upper_bound=r)
                     distances = r * np.ones(len(xy))
                     mask = np.logical_not(np.isinf(near_dists))
                     distances[mask] = near_dists[mask]
                 else:
-                    distances, _ = tree.query(xy, workers=nprocs)
+                    distances, _ = tree.query(xy, workers=pool._processes)
                 _logger.info(f'Querying KDTree took {time()-start}.')
                 values = expansion_rate*target_size*distances + target_size
                 values = values.reshape(window.height, window.width).astype(

--- a/geomesh/ops/combine_geom.py
+++ b/geomesh/ops/combine_geom.py
@@ -518,8 +518,8 @@ class GeomCombine:
                     )
             if not crs.equals(self._calc_crs):
                 _logger.info(
-                    f"Project from {crs.to_string()} to"
-                    f" {self._calc_crs.to_string()} ...")
+                    f"Project from {self._calc_crs.to_string()} to"
+                    f" {crs.to_string()} ...")
                 gdf = gdf.to_crs(crs)
             gdf.to_file(out_file)
 
@@ -530,8 +530,8 @@ class GeomCombine:
                     )
             if not crs.equals(self._calc_crs):
                 _logger.info(
-                    f"Project from {crs.to_string()} to"
-                    f" {self._calc_crs.to_string()} ...")
+                    f"Project from {self._calc_crs.to_string()} to"
+                    f" {crs.to_string()} ...")
                 gdf = gdf.to_crs(crs)
             gdf.to_feather(out_file)
 
@@ -539,8 +539,8 @@ class GeomCombine:
 
             if not crs.equals(self._calc_crs):
                 _logger.info(
-                    f"Project from {crs.to_string()} to"
-                    f" {self._calc_crs.to_string()} ...")
+                    f"Project from {self._calc_crs.to_string()} to"
+                    f" {crs.to_string()} ...")
                 transformer = Transformer.from_crs(
                     self._calc_crs, crs, always_xy=True)
                 multi_polygon = ops.transform(

--- a/geomesh/ops/combine_geom.py
+++ b/geomesh/ops/combine_geom.py
@@ -187,6 +187,7 @@ class GeomCombine:
 #
 #            with Pool(processes=nprocs) as p:
 #                p.starmap(self._process_priority, priority_args)
+#            p.join()
 
             _logger.info("Processing DEM contours ...")
             # Process contours
@@ -202,6 +203,7 @@ class GeomCombine:
                         p.starmap(
                             self._parallel_get_polygon_worker,
                             parallel_args))
+                p.join()
             else:
                 poly_files_coll.extend(
                     self._serial_get_polygon(

--- a/geomesh/ops/combine_geom.py
+++ b/geomesh/ops/combine_geom.py
@@ -10,6 +10,7 @@ from typing import Union, Sequence, Tuple, List
 import pandas as pd
 import geopandas as gpd
 import numpy as np
+from pyproj import CRS, Transformer
 from shapely import ops
 from shapely.geometry import box, Polygon, MultiPolygon, LinearRing
 from shapely.validation import explain_validity
@@ -37,9 +38,11 @@ class GeomCombine:
             zmax: Union[float, None] = None,
             chunk_size: Union[int, None] = None,
             overlap: Union[int, None] = None,
-            nprocs: int = -1):
+            nprocs: int = -1,
+            out_crs: Union[str, CRS] = "EPSG:4326",
+            base_crs: Union[str, CRS] = None):
 
-
+        self._calc_crs = None
         self._base_exterior = None
 
         nprocs = cpu_count() if nprocs == -1 else nprocs
@@ -56,7 +59,9 @@ class GeomCombine:
             zmax=zmax,
             chunk_size=chunk_size,
             overlap=overlap,
-            nprocs=nprocs)
+            nprocs=nprocs,
+            out_crs=out_crs,
+            base_crs=base_crs)
 
     def run(self):
 
@@ -71,17 +76,61 @@ class GeomCombine:
         chunk_size = self._operation_info['chunk_size']
         overlap = self._operation_info['overlap']
         nprocs = self._operation_info['nprocs']
+        out_crs = self._operation_info['out_crs']
+        base_crs = self._operation_info['base_crs']
 
         out_dir = pathlib.Path(out_file).parent
         out_dir.mkdir(exist_ok=True, parents=True)
 
+        # Warping takes time; to optimize, only warp rasters
+        # during calculation of polygons if needed. Otherwise
+        # only warp polygon before writing to file
+        if isinstance(out_crs, str):
+            out_crs = CRS.from_user_input(out_crs)
+        if isinstance(base_crs, str):
+            base_crs = CRS.from_user_input(base_crs)
+        all_crs = set(Raster(dem).crs for dem in dem_files)
+        self._calc_crs = out_crs
+        if len(all_crs) == 1:
+            self._calc_crs = list(all_crs)[0]
+            _logger.info(
+                f"All DEMs have the same CRS:"
+                f" {self._calc_crs.to_string()}")
+            
         base_mult_poly = None
         if mesh_mp_in:
+            # Assumption: If base_mult_poly is provided, it's in 
+            # base_crs if not None, else in out_crs
             base_mult_poly = self._get_valid_multipolygon(mesh_mp_in)
+            if base_crs == None:
+                base_crs = out_crs
+            if not base_crs.equals(self._calc_crs):
+                _logger.info("Reprojecting base polygon...")
+                transformer = Transformer.from_crs(
+                    base_crs, self._calc_crs, always_xy=True)
+                base_mult_poly = ops.transform(
+                        transformer.transform, base_mult_poly)
 
         elif mesh_file and pathlib.Path(mesh_file).is_file():
             _logger.info("Creating mesh object from file...")
-            base_mesh = Mesh.open(mesh_file)
+            base_mesh = Mesh.open(mesh_file, crs=base_crs)
+            mesh_crs = base_mesh.crs
+            # Assumption: If mesh_crs is not defined, mesh is in
+            # base_crs if not None, else inout_crs
+            if base_crs == None:
+                if mesh_crs:
+                    base_crs = mesh_crs
+                else:
+                    base_crs = out_crs
+            if not self._calc_crs.equals(base_crs):
+                _logger.info("Reprojecting base mesh...")
+                transformer = Transformer.from_crs(
+                    base_crs, self._calc_crs, always_xy=True)
+                xy = base_mesh.coord
+                xy = np.vstack(
+                    transformer.transform(xy[:, 0], xy[:, 1])).T
+                base_mesh.coord[:] = xy
+
             _logger.info("Done")
 
             _logger.info("Getting mesh hull polygons...")
@@ -170,14 +219,16 @@ class GeomCombine:
 
             rasters_gdf = gpd.GeoDataFrame(
                     columns=['geometry'],
-                    crs='EPSG:4326'
+                    crs=self._calc_crs
                 )
             for feather_f in poly_files_coll:
                 rasters_gdf = rasters_gdf.append(
                     gpd.GeoDataFrame(
                         {'geometry': self._read_multipolygon(
                                                 feather_f)
-                        }),
+                        },
+                        crs=self._calc_crs
+                        ),
                     ignore_index=True)
 
 
@@ -194,7 +245,7 @@ class GeomCombine:
             fin_mult_poly = self._get_valid_multipolygon(fin_mult_poly)
 
             self._write_to_file(
-                    out_format, out_file, fin_mult_poly, 'EPSG:4326')
+                    out_format, out_file, fin_mult_poly, out_crs)
 
         self._base_exterior = None
 
@@ -274,7 +325,8 @@ class GeomCombine:
                 chunk_size=chunk_size,
                 overlap=overlap)
         # Can cause issue with bbox(?)
-        rast.warp(dst_crs='EPSG:4326')
+        if not self._calc_crs.equals(rast.crs):
+            rast.warp(dst_crs=self._calc_crs)
 
         pri_dt_path = (
             pathlib.Path(temp_dir) / f'dem_priority_{priority}.feather')
@@ -312,7 +364,8 @@ class GeomCombine:
                     chunk_size=chunk_size,
                     overlap=overlap)
             # Can cause issue with bbox(?)
-            rast.warp(dst_crs='EPSG:4326')
+            if not self._calc_crs.equals(rast.crs):
+                rast.warp(dst_crs=self._calc_crs)
 
             _logger.info("Clipping to basemesh size if needed...")
             rast_box = box(*rast.src.bounds)
@@ -358,7 +411,7 @@ class GeomCombine:
             # Processing DEM priority
 #            priority_geodf = gpd.GeoDataFrame(
 #                    columns=['geometry'],
-#                    crs='EPSG:4326')
+#                    crs=self._calc_crs)
 #            for p in range(priority):
 #                higher_pri_path = (
 #                    pathlib.Path(temp_dir) / f'dem_priority_{p}.feather')
@@ -459,18 +512,40 @@ class GeomCombine:
 
         # TODO: Check for correct extension on out_file
         if out_format == "shapefile":
-            gpd.GeoDataFrame(
+            gdf = gpd.GeoDataFrame(
                     {'geometry': multi_polygon},
-                    crs=crs
-                    ).to_file(out_file)
+                    crs=self._calc_crs
+                    )
+            if not crs.equals(self._calc_crs):
+                _logger.info(
+                    f"Project from {crs.to_string()} to"
+                    f" {self._calc_crs.to_string()} ...")
+                gdf = gdf.to_crs(crs)
+            gdf.to_file(out_file)
 
         elif out_format == "feather":
-            gpd.GeoDataFrame(
+            gdf = gpd.GeoDataFrame(
                     {'geometry': multi_polygon},
-                    crs=crs
-                    ).to_feather(out_file)
+                    crs=self._calc_crs
+                    )
+            if not crs.equals(self._calc_crs):
+                _logger.info(
+                    f"Project from {crs.to_string()} to"
+                    f" {self._calc_crs.to_string()} ...")
+                gdf = gdf.to_crs(crs)
+            gdf.to_feather(out_file)
 
         elif out_format in ("jigsaw", "vtk"):
+
+            if not crs.equals(self._calc_crs):
+                _logger.info(
+                    f"Project from {crs.to_string()} to"
+                    f" {self._calc_crs.to_string()} ...")
+                transformer = Transformer.from_crs(
+                    self._calc_crs, crs, always_xy=True)
+                multi_polygon = ops.transform(
+                        transformer.transform, multi_polygon)
+
             msh = jigsaw_msh_t()
             msh.ndims = +2
             msh.mshID = 'euclidean-mesh'

--- a/geomesh/ops/combine_hfun.py
+++ b/geomesh/ops/combine_hfun.py
@@ -29,6 +29,7 @@ class HfunCombine:
             constants: List[List[float]] = None,
             chunk_size: Union[int, None] = None,
             overlap: Union[int, None] = None,
+            method: str = 'exact',
             nprocs: int = -1):
 
 
@@ -45,6 +46,7 @@ class HfunCombine:
             constants=constants,
             chunk_size=chunk_size,
             overlap=overlap,
+            method=method,
             nprocs=nprocs)
 
     def run(self):
@@ -59,6 +61,7 @@ class HfunCombine:
         constants = self._operation_info['constants']
         chunk_size = self._operation_info['chunk_size']
         overlap = self._operation_info['overlap']
+        method = self._operation_info['method']
         nprocs = self._operation_info['nprocs']
 
         nprocs = cpu_count() if nprocs == -1 else nprocs
@@ -81,7 +84,7 @@ class HfunCombine:
         logging.info("Creating Hfun from rasters...")
         hfun_collector = Hfun(
                 rast_list, base_mesh=base_mesh,
-                hmin=hmin, hmax=hmax, nprocs=nprocs)
+                hmin=hmin, hmax=hmax, nprocs=nprocs, method=method)
 
         for contour in contours:
             logging.info("Adding contour refinement...")

--- a/geomesh/ops/combine_hfun.py
+++ b/geomesh/ops/combine_hfun.py
@@ -26,6 +26,7 @@ class HfunCombine:
             hmin: Union[float, None] = None,
             hmax: Union[float, None] = None,
             contours: List[List[float]] = None,
+            constants: List[List[float]] = None,
             chunk_size: Union[int, None] = None,
             overlap: Union[int, None] = None,
             nprocs: int = -1):
@@ -41,6 +42,7 @@ class HfunCombine:
             hmin=hmin,
             hmax=hmax,
             contours=contours,
+            constants=constants,
             chunk_size=chunk_size,
             overlap=overlap,
             nprocs=nprocs)
@@ -54,6 +56,7 @@ class HfunCombine:
         hmin = self._operation_info['hmin']
         hmax = self._operation_info['hmax']
         contours = self._operation_info['contours']
+        constants = self._operation_info['constants']
         chunk_size = self._operation_info['chunk_size']
         overlap = self._operation_info['overlap']
         nprocs = self._operation_info['nprocs']
@@ -101,6 +104,10 @@ class HfunCombine:
 
             hfun_collector.add_contour(
                 level, expansion_rate, target_size)
+
+        for lower_bound, target_size in constants:
+            hfun_collector.add_constant_value(
+                    value=target_size, lower_bound=lower_bound)
 
         self._write_to_file(
                 out_format, out_file, hfun_collector, 'EPSG:4326')

--- a/geomesh/utils.py
+++ b/geomesh/utils.py
@@ -474,7 +474,9 @@ def clip_mesh_by_vertex(
                     for element in new_quads_unfinished])
 
         new_coord = coord[list(crd_old_to_new.keys()), :]
-        value = mesh.value[list(crd_old_to_new.keys())].copy()
+        value = np.zeros(shape=(0, 0), dtype=jigsaw_msh_t.REALS_t)
+        if len(mesh.value) == len(coord):
+            value = mesh.value[list(crd_old_to_new.keys())].copy()
 
 
         mesh_out = jigsaw_msh_t()

--- a/geomesh/utils.py
+++ b/geomesh/utils.py
@@ -217,28 +217,28 @@ def finalize_mesh(mesh, sieve_area=None):
 
     cleanup_isolates(mesh)
 
-    # Checks
-    pinched_nodes = get_pinched_nodes(mesh)
-    
-    boundary_polys = get_mesh_polygons(mesh)
-    sieve_mask = _get_sieve_mask(mesh, boundary_polys, sieve_area)
+    while True:
+        no_op = True
 
-    while np.any(sieve_mask) or len(pinched_nodes):
-
-        clip_mesh_by_vertex(
-            mesh, pinched_nodes,
-            can_use_other_verts=True,
-            inverse=True, in_place=True)
-
-        _sieve_by_mask(mesh, sieve_mask)
-
-        # Checks
         pinched_nodes = get_pinched_nodes(mesh)
+        if len(pinched_nodes):
+            no_op = False
+            # TODO drop fewer elements for pinch
+            clip_mesh_by_vertex(
+                mesh, pinched_nodes,
+                can_use_other_verts=True,
+                inverse=True, in_place=True)
 
         boundary_polys = get_mesh_polygons(mesh)
         sieve_mask = _get_sieve_mask(mesh, boundary_polys, sieve_area)
+        if np.sum(sieve_mask):
+            no_op = False
+            _sieve_by_mask(mesh, sieve_mask)
 
-#    cleanup_isolates(mesh)
+        if no_op:
+            break;
+
+    cleanup_isolates(mesh)
     put_IDtags(mesh)
 
 

--- a/geomesh/utils.py
+++ b/geomesh/utils.py
@@ -363,7 +363,7 @@ def get_verts_in_shape(
         mesh: jigsaw_msh_t,
         shape: Union[box, Polygon, MultiPolygon],
         from_box: bool = False,
-        ) -> Sequence[bool]:
+        ) -> Sequence[int]:
 
     if from_box:
         crd = mesh.vert2['coord']
@@ -426,7 +426,7 @@ def clip_mesh_by_shape(
 
 def clip_mesh_by_vertex(
         mesh: jigsaw_msh_t,
-        is_vert_in: Sequence[bool],
+        is_vert_in: Sequence[int],
         can_use_other_verts: bool = False,
         inverse: bool = False,
         ) -> jigsaw_msh_t:

--- a/geomesh/utils.py
+++ b/geomesh/utils.py
@@ -147,7 +147,8 @@ def remesh_small_elements(opts, geom, mesh, hfun):
         fixed_mesh = jigsawpy.jigsaw_msh_t()
         fixed_mesh.mshID = 'euclidean-mesh'
         fixed_mesh.ndims = +2
-        fixed_mesh.crs = mesh.crs
+        if hasattr(mesh, 'crs'):
+            fixed_mesh.crs = mesh.crs
 
         jigsawpy.lib.jigsaw(
             opts, geom, fixed_mesh, init=mesh_clip, hfun=hfun)


### PR DESCRIPTION
- CRS check in geom combine to avoid unnecessary warp
- Hfun-Raster to accept multiprocessing pool argument to avoid costly creation of pool for a collector type call
- Fast prototyping Hfun collector capability (in addition to original methods) 
- Remeshing fix for tiny elements before calling finalize on mesh
- Improve finalize performance and logic (sieve, pinch nodes, isolate )
- Hfun and Geom collector to accept shapely object as their base (instead of/in addition to base mesh)